### PR TITLE
Create basic pets API

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -6,4 +6,4 @@ assert version_info >= MIN_VERSION, f'requires Python {".".join([str(n) for n in
 
 
 if __name__ == '__main__':
-    webservice.run(host='0.0.0.0')
+    webservice.run(host='0.0.0.0', port=5001)

--- a/backend/webserver/__init__.py
+++ b/backend/webserver/__init__.py
@@ -1,5 +1,7 @@
 from flask import Flask
 
+name = 'DestinyAPI'
+version = '1.0'
 app = Flask(__name__)
 
 from webserver import routes

--- a/backend/webserver/routes.py
+++ b/backend/webserver/routes.py
@@ -1,6 +1,29 @@
-from webserver import app
+from flask import jsonify, request
+from random import randint, sample
+from json import load
+from webserver import app, name, version
 
+data_folder = '../data'
+pets = load(open(f'{data_folder}/master.json'))['count']
 
 @app.route('/')
 def index():
-    return 'Hello world!'
+    return jsonify(name=name, version=version)
+
+@app.route('/pet')
+def get_random_pet():
+    selection = randint(0, pets - 1)
+    data = load(open(f'{data_folder}/data_{str(selection)}.json'))
+    return jsonify(sample(data, 1)[0])
+
+
+@app.route('/pets')
+def get_random_pets():
+    count = 5
+    try:
+        count = int(request.args['count'])
+    except:
+        pass
+    selection = randint(0, pets - 1)
+    data = load(open(f'{data_folder}/data_{str(selection)}.json'))
+    return jsonify(sample(data, count))


### PR DESCRIPTION
# Pets API

## Quickstart

To use, execute package `backend` with entry point `app.py` and service starts on port 5001.

## Steps

Requires Python 3.7+ in PATH.

```bash
pip3 install -r requirements.txt
cd backend
python app.py
```

Navigate to http://localhost:5001 to see the server in action.

## Usage

Relevant endpoints are `/pet` and `/pets`.

### /pet

Send GET request, get back one pet's data.

### /pets

Accepts query parameter `count` for any arbitrary integer up to 500. (Service can be slow for high amounts). Default to 5 if not provided.

Examples:

```
GET /pets --> Returns [Pet, Pet, Pet, Pet, Pet]
```

```
GET /pets?query=3 --> Returns [Pet, Pet, Pet]
```

```
GET /pets?query=0 --> Returns []
```

## Relevant Pull Requests

Closes #9 